### PR TITLE
Relax peer dependencies to react@16.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#16](https://github.com/compulim/use-state-with-ref/pull/16) and [#18](https://github.com/compulim/use-state-with-ref/pull/18)
+- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/compulim/use-state-with-ref/pull/XX)
+- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#16](https://github.com/compulim/use-state-with-ref/pull/16), [#18](https://github.com/compulim/use-state-with-ref/pull/18), and [#XX](https://github.com/compulim/use-state-with-ref/pull/XX)
    - Production dependencies
       - [`@babel/runtime-corejs3@7.23.6`](https://npmjs.com/package/@babel/runtime-corejs3)
-      - [`use-ref-from@0.0.3`](https://npmjs.com/package/use-ref-from)
+      - [`use-ref-from@0.1.0`](https://npmjs.com/package/use-ref-from)
    - Development dependencies
       - [`@babel/cli@7.23.4`](https://npmjs.com/package/@babel/cli)
       - [`@babel/core@7.23.6`](https://npmjs.com/package/@babel/core)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/compulim/use-state-with-ref/pull/XX)
-- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#16](https://github.com/compulim/use-state-with-ref/pull/16), [#18](https://github.com/compulim/use-state-with-ref/pull/18), and [#XX](https://github.com/compulim/use-state-with-ref/pull/XX)
+- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#20](https://github.com/compulim/use-state-with-ref/pull/20)
+- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#16](https://github.com/compulim/use-state-with-ref/pull/16), [#18](https://github.com/compulim/use-state-with-ref/pull/18), and [#20](https://github.com/compulim/use-state-with-ref/pull/20)
    - Production dependencies
       - [`@babel/runtime-corejs3@7.23.6`](https://npmjs.com/package/@babel/runtime-corejs3)
       - [`use-ref-from@0.1.0`](https://npmjs.com/package/use-ref-from)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2076,9 +2076,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.6.tgz",
-      "integrity": "sha512-Djs/ZTAnpyj0nyg7p1J6oiE/tZ9G2stqAFlLGZynrW+F3k2w2jGK2mLOBxzYIOcZYA89+c3d3wXKpYLcpwcU6w==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.24.1.tgz",
+      "integrity": "sha512-T9ko/35G+Bkl+win48GduaPlhSlOjjE5s1TeiEcD+QpxlLQnoEfb/nO/T+TQqkm+ipFwORn+rB8w14iJ/uD0bg==",
       "dependencies": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
@@ -9482,15 +9482,15 @@
       }
     },
     "node_modules/use-ref-from": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/use-ref-from/-/use-ref-from-0.0.3.tgz",
-      "integrity": "sha512-+HY0IesN9DMuD0gnvGP3U2NTWYE+AwdCQnuuihpi5tNeFxQGPEcWH7b8ayvwElYJm6RcHsuo7lnVd+do02ghnQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/use-ref-from/-/use-ref-from-0.1.0.tgz",
+      "integrity": "sha512-PRjmfhUGUKghhOjKV1dBU66M7CASdb4NkMsaaWLdJA81yOZFlVL7Pi3O9aD+68pRh0VrRQjZfS6Ux3vPy1VhRg==",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.23.1",
-        "use-ref-from": "^0.0.3"
+        "@babel/runtime-corejs3": "^7.24.1",
+        "use-ref-from": "^0.1.0"
       },
       "peerDependencies": {
-        "react": ">=16.9.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/use-state-with-ref": {
@@ -9842,7 +9842,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.23.6",
-        "use-ref-from": "^0.0.3"
+        "use-ref-from": "^0.1.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.4",
@@ -9864,7 +9864,7 @@
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
-        "react": ">=16.9.0"
+        "react": ">=16.8.0"
       }
     },
     "packages/use-state-with-ref/node_modules/escape-string-regexp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "use-state-with-ref",
-  "version": "0.0.2-0",
+  "version": "0.1.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "use-state-with-ref",
-      "version": "0.0.2-0",
+      "version": "0.1.0-0",
       "license": "MIT",
       "workspaces": [
         "packages/use-state-with-ref",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-state-with-ref",
-  "version": "0.0.2-0",
+  "version": "0.1.0-0",
   "description": "",
   "private": true,
   "author": "William Wong (https://github.com/compulim)",

--- a/packages/integration-test/importDefault.test.mjs
+++ b/packages/integration-test/importDefault.test.mjs
@@ -1,7 +1,18 @@
 /** @jest-environment jsdom */
 
-import { act, renderHook } from '@testing-library/react';
 import { useStateWithRef } from 'use-state-with-ref';
+
+const act =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').act ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').act;
+
+const renderHook =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('simple scenario', async () => {
   let hoistedSetValue;

--- a/packages/integration-test/importDefault.test.mjs
+++ b/packages/integration-test/importDefault.test.mjs
@@ -30,7 +30,7 @@ test('simple scenario', async () => {
   expect(result).toHaveProperty('current', 123);
   expect(hoistedValueRef).toHaveProperty('current', 123);
 
-  await act(() => hoistedSetValue(789));
+  act(() => hoistedSetValue(789));
 
   expect(result).toHaveProperty('current', 789);
   expect(hoistedValueRef).toHaveProperty('current', 789);

--- a/packages/integration-test/importNamed.test.mjs
+++ b/packages/integration-test/importNamed.test.mjs
@@ -30,7 +30,7 @@ test('simple scenario', async () => {
   expect(result).toHaveProperty('current', 123);
   expect(hoistedValueRef).toHaveProperty('current', 123);
 
-  await act(() => hoistedSetValue(789));
+  act(() => hoistedSetValue(789));
 
   expect(result).toHaveProperty('current', 789);
   expect(hoistedValueRef).toHaveProperty('current', 789);

--- a/packages/integration-test/importNamed.test.mjs
+++ b/packages/integration-test/importNamed.test.mjs
@@ -1,7 +1,18 @@
 /** @jest-environment jsdom */
 
-import { act, renderHook } from '@testing-library/react';
 import useStateWithRef from 'use-state-with-ref/useStateWithRef';
+
+const act =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').act ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').act;
+
+const renderHook =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('simple scenario', async () => {
   let hoistedSetValue;

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -14,6 +14,28 @@
   },
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",
+  "switch:react:16": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@testing-library/react-hooks": "latest",
+      "react": "16.8.0",
+      "react-test-renderer": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@testing-library/react-hooks": "latest",
+      "react": "17.0.0",
+      "react-test-renderer": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "react": "18.0.0",
+      "react-test-renderer": "18.0.0"
+    }
+  },
   "localPeerDependencies": {
     "use-state-with-ref": "^0.0.0-0"
   },

--- a/packages/integration-test/requireDefault.test.cjs
+++ b/packages/integration-test/requireDefault.test.cjs
@@ -1,7 +1,18 @@
 /** @jest-environment jsdom */
 
-const { act, renderHook } = require('@testing-library/react');
 const { useStateWithRef } = require('use-state-with-ref');
+
+const act =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').act ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').act;
+
+const renderHook =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('simple scenario', async () => {
   let hoistedSetValue;

--- a/packages/integration-test/requireDefault.test.cjs
+++ b/packages/integration-test/requireDefault.test.cjs
@@ -30,7 +30,7 @@ test('simple scenario', async () => {
   expect(result).toHaveProperty('current', 123);
   expect(hoistedValueRef).toHaveProperty('current', 123);
 
-  await act(() => hoistedSetValue(789));
+  act(() => hoistedSetValue(789));
 
   expect(result).toHaveProperty('current', 789);
   expect(hoistedValueRef).toHaveProperty('current', 789);

--- a/packages/integration-test/requireNamed.test.cjs
+++ b/packages/integration-test/requireNamed.test.cjs
@@ -1,7 +1,18 @@
 /** @jest-environment jsdom */
 
-const { act, renderHook } = require('@testing-library/react');
 const { default: useStateWithRef } = require('use-state-with-ref/useStateWithRef');
+
+const act =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').act ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').act;
+
+const renderHook =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('simple scenario', async () => {
   let hoistedSetValue;

--- a/packages/integration-test/requireNamed.test.cjs
+++ b/packages/integration-test/requireNamed.test.cjs
@@ -30,7 +30,7 @@ test('simple scenario', async () => {
   expect(result).toHaveProperty('current', 123);
   expect(hoistedValueRef).toHaveProperty('current', 123);
 
-  await act(() => hoistedSetValue(789));
+  act(() => hoistedSetValue(789));
 
   expect(result).toHaveProperty('current', 789);
   expect(hoistedValueRef).toHaveProperty('current', 789);

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -16,6 +16,36 @@
   },
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",
+  "switch:react:16": {
+    "devDependencies": {
+      "@types/react": "^16",
+      "@types/react-dom": "^16"
+    },
+    "dependencies": {
+      "react": "16.8.0",
+      "react-dom": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@types/react": "^17",
+      "@types/react-dom": "^17"
+    },
+    "dependencies": {
+      "react": "17.0.0",
+      "react-dom": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18",
+      "@types/react-dom": "^18"
+    },
+    "dependencies": {
+      "react": "18.0.0",
+      "react-dom": "18.0.0"
+    }
+  },
   "localPeerDependencies": {
     "use-state-with-ref": "^0.0.0-0"
   },

--- a/packages/use-state-with-ref/package.json
+++ b/packages/use-state-with-ref/package.json
@@ -66,8 +66,33 @@
     "url": "https://github.com/compulim/use-state-with-ref/issues"
   },
   "homepage": "https://github.com/compulim/use-state-with-ref#readme",
+  "switch:react:16": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@testing-library/react-hooks": "latest",
+      "@types/react": "^16",
+      "react": "16.8.0",
+      "react-test-renderer": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@testing-library/react-hooks": "latest",
+      "@types/react": "^17",
+      "react": "17.0.0",
+      "react-test-renderer": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18",
+      "react": "18.0.0",
+      "react-test-renderer": "18.0.0"
+    }
+  },
   "peerDependencies": {
-    "react": ">=16.9.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.4",
@@ -90,6 +115,6 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.23.6",
-    "use-ref-from": "^0.0.3"
+    "use-ref-from": "^0.1.0"
   }
 }

--- a/packages/use-state-with-ref/src/useStateWithRef.spec.ts
+++ b/packages/use-state-with-ref/src/useStateWithRef.spec.ts
@@ -1,11 +1,25 @@
 /** @jest-environment jsdom */
 
-import { act, renderHook } from '@testing-library/react';
-import { type Dispatch, type RefObject, SetStateAction } from 'react';
+import { SetStateAction, type Dispatch, type RefObject } from 'react';
 
 import useStateWithRef from './useStateWithRef';
 
 import { type useRefFrom } from 'use-ref-from';
+
+const act: <T extends Promise<void> | void>(fn: () => T) => T =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').act ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').act;
+
+const renderHook: <T, P>(
+  render: (props: P) => T,
+  options?: { initialProps: P }
+) => { rerender: (props: P) => void; result: { current: T } } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 type ReadonlyRefObject<T> = ReturnType<typeof useRefFrom<T>>;
 
@@ -79,7 +93,7 @@ test('should not change setter and RefObject', async () => {
   expect(result).toHaveProperty('current', 123);
   expect(hoistedValueRefs[0]).toHaveProperty('current', 123);
 
-  await act(() => hoistedSetValues[0](789));
+  await act(() => hoistedSetValues[0]?.(789));
 
   expect(numRender).toBe(2);
 

--- a/packages/use-state-with-ref/src/useStateWithRef.spec.ts
+++ b/packages/use-state-with-ref/src/useStateWithRef.spec.ts
@@ -6,7 +6,7 @@ import useStateWithRef from './useStateWithRef';
 
 import { type useRefFrom } from 'use-ref-from';
 
-const act: <T extends Promise<void> | void>(fn: () => T) => T =
+const act: (fn: () => void) => void =
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   require('@testing-library/react').act ||
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -48,7 +48,7 @@ test('should have setter', async () => {
 
   expect(result).toHaveProperty('current', 123);
 
-  await act(() => hoistedSetValue(789));
+  act(() => hoistedSetValue(789));
 
   expect(result).toHaveProperty('current', 789);
 });
@@ -69,7 +69,7 @@ test('should have RefObject', async () => {
   expect(result).toHaveProperty('current', 123);
   expect(hoistedValueRef).toHaveProperty('current', 123);
 
-  await act(() => hoistedSetValue(789));
+  act(() => hoistedSetValue(789));
 
   expect(result).toHaveProperty('current', 789);
   expect(hoistedValueRef).toHaveProperty('current', 789);
@@ -93,7 +93,7 @@ test('should not change setter and RefObject', async () => {
   expect(result).toHaveProperty('current', 123);
   expect(hoistedValueRefs[0]).toHaveProperty('current', 123);
 
-  await act(() => hoistedSetValues[0]?.(789));
+  act(() => hoistedSetValues[0]?.(789));
 
   expect(numRender).toBe(2);
 


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#20](https://github.com/compulim/use-state-with-ref/pull/20)
- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#16](https://github.com/compulim/use-state-with-ref/pull/16), [#18](https://github.com/compulim/use-state-with-ref/pull/18), and [#20](https://github.com/compulim/use-state-with-ref/pull/20)
   - Production dependencies
      - [`use-ref-from@0.1.0`](https://npmjs.com/package/use-ref-from)

## Specific changes

> Please list each individual specific change in this pull request.

- Run `npm version --no-git-tag-version preminor` to bump to `0.1.0-0`
- Bump `use-ref-from@0.1.0`
- Add list of dependencies for testing against various version of React